### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish packages
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/LionMarc/ng-simple-state-management/security/code-scanning/3](https://github.com/LionMarc/ng-simple-state-management/security/code-scanning/3)

To resolve the issue, add a `permissions` block that follows the principle of least privilege. Placing it at the workflow root applies it to all jobs by default. For most publishing workflows, `contents: read` is generally sufficient unless the workflow itself modifies the repository through the GitHub API (not indicated here). The `publish_packages.sh` script likely interacts only with npm and not GitHub APIs requiring write access. Thus, a minimal starting fix is to add:
```yaml
permissions:
  contents: read
```
just after the workflow `name`. If further privileges are needed, such as publishing release notes, further fine-grained permissions can be added as necessary, but the minimal fix is to set `contents: read` at the root level. This change should be made at the top of the file, immediately after the `name` field and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
