### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ name: Build CI
 permissions:
   contents: read
   pull-requests: write
+  checks: write
+  actions: read
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Build CI
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/LionMarc/ng-simple-state-management/security/code-scanning/2](https://github.com/LionMarc/ng-simple-state-management/security/code-scanning/2)

**General fix:**  
Explicitly add a `permissions` block either at the workflow root (applies to all jobs) or to the `build` job (applies to this job only). The permissions should be as restrictive as possible, minimally allowing the workflow to function.

**Detailed fix:**  
1. Examine steps that may require token permissions.  
   - `marocchino/sticky-pull-request-comment` requires `pull-requests: write`.
   - `schneegans/dynamic-badges-action` with a gist secret uses an external secret, so typically no GITHUB_TOKEN write is needed, but others might.
   - `dorny/test-reporter` sometimes comments on PRs, requiring `pull-requests: write`.
2. All other steps (checkout, setup-node, build, test, irongut/CodeCoverageSummary) only require `contents: read`.
3. The least privilege set sufficient for these steps is:  
   ```yaml
   permissions:
     contents: read
     pull-requests: write
   ```
4. Add the above `permissions` block after the `name:` (global workflow level, applies to all jobs unless overridden).
5. No other code changes needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
