### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     name: Deploy docs
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main


### PR DESCRIPTION
Potential fix for [https://github.com/LionMarc/ng-simple-state-management/security/code-scanning/1](https://github.com/LionMarc/ng-simple-state-management/security/code-scanning/1)

To fix the problem, you should explicitly add a `permissions` block to limit the GITHUB_TOKEN's access in the workflow/job. The best and minimal fix is to set `contents: read` at either the workflow or job level, as this grants only read access to repository contents. However, because the "Deploy docs" step (`mkdocs gh-deploy --force`) triggers a push to the `gh-pages` branch, it also requires `contents: write` permission in order to successfully update the GitHub Pages content. The recommended fix is to add a `permissions` block with `contents: write` at the job level, immediately under `build:` (line 9).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
